### PR TITLE
Rename "launch" -> "deploy" and avoid the term "remote"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,14 @@ FROM debian:bullseye-slim
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.title="Okteto" \
-    org.opencontainers.image.description="Remote Development Environments powered by Kubernetes" \
+    org.opencontainers.image.description="Development Environments powered by Kubernetes" \
     org.opencontainers.image.vendor="Okteto" \
     com.docker.desktop.extension.api.version=">= 0.2.3" \
     com.docker.desktop.extension.icon="https://www.okteto.com/okteto-symbol-circle-inverse-1.1.png" \
     com.docker.extension.detailed-description="Okteto enables seamless deployment of remote development environments for Docker Compose and Kubernetes applications" \
     com.docker.extension.publisher-url="https://okteto.com" \
     com.docker.extension.additional-urls="[{\"title\":\"Documentation\",\"url\":\"https://okteto.com/docs\"}, {\"title\":\"Community\",\"url\":\"https://community.okteto.com/\"}]" \
-    com.docker.extension.screenshots="[{\"alt\": \"Remote Development Environments powered by Kubernetes\", \"url\": \"https://www.okteto.com/docker-desktop-extension-marketplace-1.png\"}, {\"alt\": \"Code locally and see the results immediatelly on your remote cluster\", \"url\": \"https://www.okteto.com/docker-desktop-extension-marketplace-2.png\"}]"
+    com.docker.extension.screenshots="[{\"alt\": \"Development Environments powered by Kubernetes\", \"url\": \"https://www.okteto.com/docker-desktop-extension-marketplace-1.png\"}, {\"alt\": \"Code locally and see the results immediatelly on your remote cluster\", \"url\": \"https://www.okteto.com/docker-desktop-extension-marketplace-2.png\"}]"
 
 COPY --from=client-builder /app/client/dist ui
 COPY okteto.svg .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Extension for Okteto
 
-Remote Development Environments for your Docker Compose applications.
+A new development experience for applications running on Kubernetes.
 
 ## Overwiew
 
@@ -8,7 +8,7 @@ Do you love Docker Desktop, but your application is starting to get too big for 
 
 ## Try It Out Yourself!
 
-Using the Docker Extension for Okteto is very simple. Once you have the extension installed, simply point it to the location of the Docker compose file describing your services and click the "Launch Remote Environment" button! In a matter of minutes, all the services you require should be up and running in the cloud.
+Using the Docker Extension for Okteto is very simple. Once you have the extension installed, simply point it to the location of the Docker compose file or [Okteto Manifest](https://www.okteto.com/docs/reference/manifest/) describing your services and click the "Deploy Dev Environment" button! In a matter of minutes, all the services you require should be up and running in the cloud.
 
 ![Okteto Extension](images/extension-ui.png)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -29,7 +29,7 @@ import (
 func main() {
 	root := &cobra.Command{
 		Use:   "okteto-extension COMMAND [ARG...]",
-		Short: "Remote Development Environments powered by Kubernetes",
+		Short: "Development Environments powered by Kubernetes",
 	}
 	root.AddCommand(cmd.DevContainers())
 

--- a/client/src/contexts/Okteto.context.tsx
+++ b/client/src/contexts/Okteto.context.tsx
@@ -29,7 +29,7 @@ interface OktetoStore {
   selectDev: (file: string, devName: string) => void
   selectContext: (f: string) => void
   addContext: (f: string) => void
-  relaunchEnvironment: () => void
+  redeployEnvironment: () => void
 }
 
 type OktetoProviderProps = {
@@ -69,10 +69,10 @@ const OktetoProvider = ({ children } : OktetoProviderProps) => {
   const selectDev = (file: string, devName: string) => {
     if (!currentContext) return;
     setCurrentDev(devName);
-    launchEnvironment(file, devName);
+    deployEnvironment(file, devName);
   };
 
-  const launchEnvironment = (file: string, devName: string) => {
+  const deployEnvironment = (file: string, devName: string) => {
     if (!currentContext) return;
     setOutput('');
     setEnvironment({
@@ -87,7 +87,7 @@ const OktetoProvider = ({ children } : OktetoProviderProps) => {
   };
 
   const selectContext = async (contextName: string) => {
-    // TODO: What do we do if context is changed with an environment launched? Dialog?
+    // TODO: What do we do if context is changed with an environment deployed? Dialog?
     setLoading(true);
     const context = contextList.find(c => c.name === contextName);
     if (context) {
@@ -124,7 +124,7 @@ const OktetoProvider = ({ children } : OktetoProviderProps) => {
     setCurrentContext(context ?? null);
   };
 
-  const relaunchEnvironment = async () => {
+  const redeployEnvironment = async () => {
     if (!environment || loading) return;
 
     const {file, dev, contextName} = environment;
@@ -133,7 +133,7 @@ const OktetoProvider = ({ children } : OktetoProviderProps) => {
     selectContext(contextName);
     setCurrentManifest(file);
     setCurrentDev(dev);
-    launchEnvironment(file, dev);
+    deployEnvironment(file, dev);
   }
 
   useInterval(async () => {
@@ -167,7 +167,7 @@ const OktetoProvider = ({ children } : OktetoProviderProps) => {
       selectDev,
       selectContext,
       addContext,
-      relaunchEnvironment
+      redeployEnvironment
     }}>
       {children}
     </Okteto.Provider>

--- a/client/src/views/Environment.tsx
+++ b/client/src/views/Environment.tsx
@@ -19,7 +19,7 @@ const ENDPOINTS_POLLING_INTERVAL = 5000;
 
 function Environment() {
   const theme = useTheme();
-  const { output, environment, stopEnvironment, relaunchEnvironment } = useOkteto();
+  const { output, environment, stopEnvironment, redeployEnvironment } = useOkteto();
   const [endpoints, setEndpoints] = useState<Array<string>>([]);
 
   const handleOpenEnvironment = () => {
@@ -58,7 +58,7 @@ function Environment() {
           gap: 1
         }}>
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
-            Remote Environment
+            Dev Environment
           </Typography>
 
           <div style={{ flex: '1 auto' }} />
@@ -84,9 +84,9 @@ function Environment() {
               }
             }}
             startIcon={<ReplayIcon />}
-            onClick={relaunchEnvironment}
+            onClick={redeployEnvironment}
           >
-            Relaunch
+            Redeploy
           </Button>
           <Button
             variant="contained"

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -58,7 +58,8 @@ function Login() {
         }}>
           <Typography variant="h5" component="div">
             Ready to level up your development experience with Okteto?<br/>
-            Install Okteto on your Kubernetes cluster.
+            1) Install Okteto on your Kubernetes cluster<br/>
+            2) Add a context pointing to your cluster
           </Typography>
           <Box sx={{
             display: 'flex',
@@ -73,7 +74,7 @@ function Login() {
               sx={{ fontSize: '1.1rem' }}
               onClick={handleTrial}
             >
-              Try for Free
+              Install Okteto for Free
             </Button>
             <Button
               variant="outlined"

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -56,12 +56,9 @@ function Login() {
           alignItems: 'start',
           gap: 2
         }}>
-          <Typography variant="h4">
-            Code Locally, Run Remotely
-          </Typography>
           <Typography variant="h5" component="div">
             Ready to level up your development experience with Okteto?<br/>
-            Start by installing Okteto on your Kubernetes cluster.
+            Install Okteto on your Kubernetes cluster.
           </Typography>
           <Box sx={{
             display: 'flex',

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Card, CardContent, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 
 import logoDark from '../images/logo-dark.svg';
@@ -17,79 +17,203 @@ function Login() {
   const handleCloseDialog = () => {
     setOpen(false);
   };
-  
+
   const handleTrial = () => {
     window.ddClient.host.openExternal('https://www.okteto.com/free-trial/');
-  }
+  };
 
   return (
-    <Box sx={{
-      display: 'flex',
-      flex: 1,
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      height: '100%',
-      gap: 2
-    }}>
-      <Box sx={{
+    <Box
+      sx={{
         display: 'flex',
-        flexDirection: 'row',
+        flex: 1,
+        flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: 6
-      }}>
-        <Box sx={{
+        height: '100%',
+        gap: 2,
+      }}
+    >
+      <Box
+        sx={{
           display: 'flex',
-          borderRight: '1px solid',
-          borderColor: 'white',
-          height: '100%',
+          flexDirection: 'row',
+          alignItems: 'center',
           justifyContent: 'center',
-          pr: 6,
-        }}>
-          <img src={theme.palette.mode === 'dark' ? logoDark : logoLight} width="240" />
-        </Box>
-        <Box sx={{
-          display: 'flex',
-          flex: 1,
-          flexDirection: 'column',
-          alignItems: 'start',
-          gap: 2
-        }}>
-          <Typography variant="h5" component="div">
-            Ready to level up your development experience with Okteto?
-            <ol>
-              <li>Install Okteto on your Kubernetes cluster</li>
-              <li>Add a context pointing to your cluster</li>
-            </ol>
-          </Typography>
-          <Box sx={{
+          gap: 6,
+        }}
+      >
+        <Box
+          sx={{
             display: 'flex',
-            flexDirection: 'row',
-            alignItems: 'center',
+            borderRight: '1px solid',
+            borderColor: 'white',
+            height: '100%',
             justifyContent: 'center',
-            gap: 1
-          }}>
-            <Button
-              variant="contained"
-              size="large"
-              sx={{ fontSize: '1.1rem' }}
-              onClick={handleTrial}
-            >
-              Install Okteto for Free
-            </Button>
-            <Button
+            pr: 6,
+          }}
+        >
+          <img
+            src={theme.palette.mode === 'dark' ? logoDark : logoLight}
+            width="240"
+          />
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            alignItems: 'start',
+            gap: 2,
+          }}
+        >
+          <Typography variant="h4" component="div" sx={{ maxWidth: '620px' }}>
+            Ready to level up your development experience with Okteto?
+          </Typography>
+
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              justifyContent: 'flex-start',
+              gap: 1,
+              width: '100%',
+            }}
+          >
+            <Card
               variant="outlined"
-              size="large"
-              sx={{ fontSize: '1.1rem' }}
-              onClick={handleOpenDialog}
+              sx={{
+                width: '100%',
+                maxWidth: '500px',
+                background: 'transparent',
+                border: 0
+              }}
             >
-              Add your context
-            </Button>
+              <Box
+                sx={{
+                  m: 2,
+                  flexDirection: 'column',
+                  display: 'flex',
+                  gap: 1,
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    gap: 1,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Box
+                    sx={{
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(255, 255, 255, 0.12)'
+                          : 'rgba(0, 0, 0, 0.12)',
+                      borderRadius: '50%',
+                      width: '32px',
+                      height: '32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    1
+                  </Box>
+                  <Typography variant="h5" component="div">
+                    Install Okteto on your Kubernetes cluster:
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    marginLeft: '40px'
+                  }}
+                >
+                  <Button
+                    variant="contained"
+                    size="large"
+                    sx={{ fontSize: '1.1rem' }}
+                    onClick={handleTrial}
+                  >
+                    Install Okteto for Free
+                  </Button>
+                </Box>
+              </Box>
+            </Card>
+
+            <Card
+              variant="outlined"
+              sx={{
+                width: '100%',
+                maxWidth: '500px',
+                background: 'transparent',
+                border: 0,
+              }}
+            >
+              <Box
+                sx={{
+                  m: 2,
+                  flexDirection: 'column',
+                  display: 'flex',
+                  gap: 1,
+                }}
+              >
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    gap: 1,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Box
+                    sx={{
+                      backgroundColor:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(255, 255, 255, 0.12)'
+                          : 'rgba(0, 0, 0, 0.12)',
+                      borderRadius: '50%',
+                      width: '32px',
+                      height: '32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    2
+                  </Box>
+                  <Typography variant="h5" component="div">
+                    Configure the context pointing to your cluster:
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    marginLeft: '40px'
+                  }}
+                >
+                  <Button
+                    variant="outlined"
+                    size="large"
+                    sx={{ fontSize: '1.1rem' }}
+                    onClick={handleOpenDialog}
+                  >
+                    Add your context
+                  </Button>
+                </Box>
+              </Box>
+            </Card>
           </Box>
         </Box>
       </Box>
-      <ContextDialog open={open} onClose={handleCloseDialog}/>
+      <ContextDialog open={open} onClose={handleCloseDialog} />
     </Box>
   );
 }

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -57,9 +57,11 @@ function Login() {
           gap: 2
         }}>
           <Typography variant="h5" component="div">
-            Ready to level up your development experience with Okteto?<br/>
-            1) Install Okteto on your Kubernetes cluster<br/>
-            2) Add a context pointing to your cluster
+            Ready to level up your development experience with Okteto?
+            <ol>
+              <li>Install Okteto on your Kubernetes cluster</li>
+              <li>Add a context pointing to your cluster</li>
+            </ol>
           </Typography>
           <Box sx={{
             display: 'flex',

--- a/client/src/views/SelectManifest.tsx
+++ b/client/src/views/SelectManifest.tsx
@@ -10,7 +10,7 @@ function SelectManifest() {
   const theme = useTheme();
   const { selectManifest, loading } = useOkteto();
 
-  const handleLaunch = async () => {
+  const handleDeploy = async () => {
     const result = await window.ddClient.desktopUI.dialog.showOpenDialog({
       properties: ['openFile'],
       filters: [{ name: 'Okteto Manifest', extensions: ['yml', 'yaml'] }]
@@ -39,7 +39,7 @@ function SelectManifest() {
         />
 
         <Typography variant="h6" sx={{ maxWidth: '400px', textAlign: 'center' }}>
-          Select your Okteto Manifest or Docker Compose to launch your remote development environment.
+          Select your Okteto Manifest or Docker Compose to deploy your development environment
         </Typography>
 
         <Box sx={{
@@ -54,9 +54,9 @@ function SelectManifest() {
             variant="contained"
             size="large"
             sx={{ fontSize: '1rem', height: '3.2rem' }}
-            onClick={handleLaunch}
+            onClick={handleDeploy}
           >
-            Launch Remote Environment
+            Deploy Dev Environment
           </Button>
         </Box>
       </Box>
@@ -75,7 +75,7 @@ function SelectManifest() {
       >
         <Typography variant="body1" sx={{ flex: 1 }}>
           <strong>New to Okteto?</strong><br />
-          Learn how Okteto helps simplify the application development process by leveraging remote environments.
+          Learn how Okteto helps simplify the development of microservices on Kubernetes.
         </Typography>
 
         <Button


### PR DESCRIPTION
Following the docs changes that are coming on the next chart release, this PR is updating the terms we use in the docker extension. "Launch" is renamed to "Deploy".
This is how the main page looks like now:
<img width="960" alt="Screenshot 2023-12-05 at 23 01 42" src="https://github.com/okteto/docker-desktop-extension/assets/7474696/6a941dc0-5a0e-4704-934f-198ebc7f840b">

