### PR TITLE
Fix styles for context selector in light theme

### DIFF
--- a/client/src/components/ContextSelector.tsx
+++ b/client/src/components/ContextSelector.tsx
@@ -16,7 +16,8 @@ const NEW_LABEL = '--new-context';
 function ContextSelector({}) {
   const theme = useTheme();
   const confirm = useConfirm();
-  const { environment, selectContext, currentContext, contextList, loading } = useOkteto();
+  const { environment, selectContext, currentContext, contextList, loading } =
+    useOkteto();
   const [open, setOpen] = useState(false);
 
   const handleOpenDialog = () => {
@@ -34,19 +35,20 @@ function ContextSelector({}) {
           title: 'Switch Context',
           content: (
             <Typography variant="body1">
-              Switching contexts will stop your running environment. Are you sure you want to continue?
+              Switching contexts will stop your running environment. Are you
+              sure you want to continue?
             </Typography>
           ),
           confirmationButtonProps: {
-            variant: 'contained'
+            variant: 'contained',
           },
           cancellationButtonProps: {
-            variant: 'outlined'
-          }
+            variant: 'outlined',
+          },
         });
       }
       selectContext(target.value);
-    } catch(_) {
+    } catch (_) {
       return;
     }
   };
@@ -54,20 +56,27 @@ function ContextSelector({}) {
   return (
     <FormControl sx={{ minWidth: 120 }} size="small" disabled={loading}>
       <Select
+        id="context-selector"
         value={currentContext?.name ?? ''}
         onChange={handleContextChange}
         displayEmpty
         inputProps={{ 'aria-label': 'Without label' }}
         SelectDisplayProps={{
-          style: { display: 'flex', alignItems: 'center' },
+          style: { 
+            display: 'flex', 
+            alignItems: 'center' 
+          },
         }}
+        variant="outlined"
       >
-        {contextList.length === 0 &&
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+        {contextList.length === 0 && (
           <MenuItem disabled value="">
             <em>No context found</em>
           </MenuItem>
-        }
-        {contextList.map(context => (
+        )}
+        {contextList.map((context) => (
           <MenuItem key={context.name} value={context.name}>
             <ListItemIcon>
               <CloudCircleIcon />
@@ -81,9 +90,9 @@ function ContextSelector({}) {
             <AddCircleIcon />
           </ListItemIcon>
           <ListItemText primary="Add new context" />
-          </MenuItem>
+        </MenuItem>
       </Select>
-      <ContextDialog open={open} onClose={handleCloseDialog}/>
+      <ContextDialog open={open} onClose={handleCloseDialog} />
     </FormControl>
   );
 }

--- a/client/src/components/ContextSelector.tsx
+++ b/client/src/components/ContextSelector.tsx
@@ -69,8 +69,6 @@ function ContextSelector({}) {
         }}
         variant="outlined"
       >
-        <MenuItem value={10}>Ten</MenuItem>
-        <MenuItem value={20}>Twenty</MenuItem>
         {contextList.length === 0 && (
           <MenuItem disabled value="">
             <em>No context found</em>

--- a/client/src/components/Theme.tsx
+++ b/client/src/components/Theme.tsx
@@ -1,21 +1,21 @@
 import { DockerMuiThemeProvider } from '@docker/docker-mui-theme';
 import { GlobalStyles } from '@mui/material';
-import { createTheme, Theme, ThemeProvider } from "@mui/material/styles";
+import { createTheme, Theme, ThemeProvider } from '@mui/material/styles';
 import { ReactNode } from 'react';
 
 export const colors = {
   card: {
     primary: {
       dark: '#37464e',
-      light: 'grey.300'
-    }
+      light: 'grey.300',
+    },
   },
   brand: {
     green: {
       dark: '#00D1CA',
-      light: '#0e8e9d'
-    }
-  }
+      light: '#0e8e9d',
+    },
+  },
 };
 
 export const shadows = {
@@ -24,26 +24,52 @@ export const shadows = {
     0 42px 32px rgb(0 0 0 / 5%),
     0 22px 18px rgb(0 0 0 / 4%),
     0 12px 10px rgb(0 0 0 / 4%)
-  `
+  `,
 };
 
 type ThemeProviderProps = {
-  children?: ReactNode
+  children?: ReactNode;
 };
 
 export default ({ children }: ThemeProviderProps) => {
   return (
     <DockerMuiThemeProvider>
-      <ThemeProvider theme={(theme: Theme) => 
-        createTheme({
-        ...theme,
-        // Here override of the theme.
-      })}>
-        <GlobalStyles styles={{ 
-          body: { 
-            margin: 0,
-          } 
-        }} />
+      <ThemeProvider
+        theme={(theme: Theme) =>
+          createTheme({
+            ...theme,
+            // Here override of the theme.
+            components: {
+              ...theme.components,
+              MuiMenu: {
+                styleOverrides: {
+                  ...theme.components?.MuiMenu?.styleOverrides,
+                  paper: {
+                    boxShadow: shadows.primary,
+                  },
+                },
+              },
+              MuiMenuItem: {
+                styleOverrides: {
+                  ...theme.components?.MuiMenuItem?.styleOverrides,
+                  root: {
+                    '&:hover': {
+                      backgroundColor: theme.palette.divider
+                    },
+                  },
+                },
+              },
+            },
+          })
+        }
+      >
+        <GlobalStyles
+          styles={{
+            body: {
+              margin: 0,
+            },
+          }}
+        />
         {children}
       </ThemeProvider>
     </DockerMuiThemeProvider>

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -47,7 +47,7 @@ function Login() {
           sx={{
             display: 'flex',
             borderRight: '1px solid',
-            borderColor: 'white',
+            borderColor: theme.palette.divider,
             height: '100%',
             justifyContent: 'center',
             pr: 6,


### PR DESCRIPTION
Fixes context selector rendering colors when in the light theme. The "Add context" option was white and cannot be visible with this theme.

| Before  | After |
| ------------- | ------------- |
|  <img width="799" alt="Screenshot 2023-12-14 at 17 30 27" src="https://github.com/okteto/docker-desktop-extension/assets/237819/b7583dc6-eb6d-44f6-ac16-db7f2a4339c1"> | <img width="798" alt="Screenshot 2023-12-14 at 17 31 28" src="https://github.com/okteto/docker-desktop-extension/assets/237819/9154056c-aeaf-495f-9097-73b6437e3606"> |
